### PR TITLE
Fix Search page display

### DIFF
--- a/templates/pages/search.twig
+++ b/templates/pages/search.twig
@@ -4,7 +4,7 @@
 
     {% include 'blocks/page-header.twig' %}
 
-    {% if posts.post_count == 0 %}
+    {% if posts == [] %}
         {{ __('Sorry, no results were found.', 'sage') }}
         {{ function('get_search_form') }}
     {% endif %}

--- a/templates/pages/search.twig
+++ b/templates/pages/search.twig
@@ -10,7 +10,7 @@
     {% endif %}
 
     {% for post in posts %}
-        {% include "templates/content.twig" with {post: post}  %}
+        {% include "templates/blocks/content.twig" with {post: post}  %}
     {% endfor %}
 
     {{ function('the_posts_navigation') }}


### PR DESCRIPTION
In a new project, the search page didn't display at all, because search.twig didn't point to content.twig correctly. I fixed that, and then fixed the conditional check against 0 search results, to prevent the "Sorry, no results..." text from appearing even when there are results. I'm not 100% sure that I solved that the best possible way, but it works in my testing.